### PR TITLE
Fixes local value fetch when cloud item exists

### DIFF
--- a/Lib/UICKeyChainStore/UICKeyChainStore.m
+++ b/Lib/UICKeyChainStore/UICKeyChainStore.m
@@ -453,7 +453,12 @@ static NSString *_defaultService;
     query[(__bridge __strong id)kSecReturnData] = (__bridge id)kCFBooleanTrue;
     
     query[(__bridge __strong id)kSecAttrAccount] = key;
-    
+
+    // Set the query to return a value that matches the synchronizable setting of this
+    // keychain. This means if two values exist, one in the cloud and one local, the returned
+    // value will be cloud version if synchronizable is true, or local if false
+    query[(__bridge __strong id)kSecAttrSynchronizable] = @(_synchronizable);
+
     CFTypeRef data = nil;
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &data);
     


### PR DESCRIPTION
The issue is that if there exists both a local key and cloud key in the keychain at the same time, it is not guaranteed which one will be returned when you query for a value because of the parameters that are set by this framework.

`query[(__bridge __strong id)kSecAttrSynchronizable] = (__bridge id)kSecAttrSynchronizableAny;`

Note that the above basically says just give me any value for this key, even if that value is from the cloud but I only care about local keychain.

This state of having two values in the keychain can happen for the TuneInApp:

if on one device I am on the latest version of the app that has synchonizable disabled for the auth token keychain
and my other device is on an older version that is using a synchonizable auth token keychain (cause of the SPM PR 🤦).
This is how 2 values could be in the keychain at the same time. Then, because of the way this framework is setup, we were basically saying "Query the keychain for this key but only give me the first value you find" where the first value is not guaranteed to match the synchonizable state of your keychain.

This PR makes it so that the query to get a value will guarantee that the value returned matches how you set up the keychain. So if for example, there was only a cloud value set in the keychain (from your second device), but no local value, and you queried from your device on the code that uses a local keychain for auth tokens, the query now would return nil because there is no local value (only a cloud value).

Note: the newer swift version of this framework has an option in the query methods to decide if it should ignore the sync status for queries or force them... so effectively in the newer version this wouldn't be a problem if we used the query with ignoringAttributeSynchronizable set to false.