### PR TITLE
Fixes issue setting a string when multiple versions of the key exist

### DIFF
--- a/Lib/UICKeyChainStore/UICKeyChainStore.m
+++ b/Lib/UICKeyChainStore/UICKeyChainStore.m
@@ -577,7 +577,13 @@ static NSString *_defaultService;
             } else {
                 status = SecItemUpdate((__bridge CFDictionaryRef)query, (__bridge CFDictionaryRef)attributes);
             }
-            if (status != errSecSuccess) {
+            if (status == errSecDuplicateItem) {
+                // Duplicate items exist, meaning one synchronizable and one not. Remove them and try again.
+                if ([self removeItemForKey:key error:error]) {
+                    // Success remove, try to set again
+                    return [self setData:data forKey:key label:label comment:comment error:error];
+                }
+            } else if (status != errSecSuccess) {
                 NSError *e = [self.class securityError:status];
                 if (error) {
                     *error = e;


### PR DESCRIPTION
This happens when there are two items in the keychain for the same key, one being synchronizable and the other not. When you try to set a string for that key, it would fail saying that duplicate items exist (it didn't know which one to set since the code isn't specifying the synchronizable value)

This code uses similar code to other error paths, where if we detect a failure to update an existing key because duplicate items exist, we will first try to delete the items, then set it again. You can basically see the same code ~6ish lines up from the added code here for other cases.

I've tested this with my own test app.
1. set local string on device 1
2. set cloud string on device 2
3. try to set local string on device 1 (after sync)
4. Before: Failed. After: Success

This is going to be a large portion of the issues people are having in prod with 401s... once you have 2 items in the keychain (iPad + iPhone on different app versions, for example), any time after that updating the token after expiration is going to fail. Well this code fixes that